### PR TITLE
Bump micadoparser version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ Werkzeug==2.0.1
 oauth2client==4.1.3
 ruamel.yaml==0.17.16
 boto3==1.20.46
-micado-parser==0.12.0
+micado-parser==0.12.1
 git+https://github.com/uow-cpc/dockubeadt


### PR DESCRIPTION
- This will support the `secret` custom tosca type (for open parameters)