### PR TITLE
Support ${} for params

### DIFF
--- a/adtg_generate.py
+++ b/adtg_generate.py
@@ -7,6 +7,7 @@ import jinja2, jinja2schema
 from adtg_file import *
 from adtg_compile import compile
 import adtg_conf
+import adtg_utils as utils
 from urllib.parse import urlparse
 import requests
 
@@ -200,6 +201,10 @@ def prepare_and_validate_input_assets(input_data, amr_endpoint, full_wd):
         if isinstance(ms['deployment_data'],str):
             newdd = json.loads(ms['deployment_data'])
             ms['deployment_data']=newdd
+        
+        ms["deployment_data"] = utils.handle_env_braces(
+            ms["deployment_data"], ms.get("parameters", [])
+        )
     add_log(full_wd, 'Validating incoming json finished.\n')
     return lc_data
 

--- a/adtg_utils.py
+++ b/adtg_utils.py
@@ -1,0 +1,44 @@
+import re
+
+def handle_env_braces(deploy_data: dict, ms_params: list) -> dict:
+    """
+    Turn ${} env-style braces into either {{ }} or open_parameter()
+
+    Args:
+        deploy_data (dict): Deployment data (Compose or Kubernetes)
+        ms_params (list[dict]): Open parameters
+
+    Returns:
+        dict: Updated deployment data
+    """
+    params = [
+        param.get("name") 
+        for param in ms_params
+        if param.get("name")
+    ]
+
+    def replacer(match: re.Match) -> str:
+        """
+        Replace matched string patterns according to open params. To
+        be used by recursive_replace().
+        """
+        variable_name = match.group(1)
+        if variable_name in params:
+            return f'open_parameter({variable_name})'
+        else:
+            return f'{{{{ {variable_name} }}}}'  
+
+    def recursive_replace(item):
+        """
+        Recursively find and replace ${} in the deployment data.
+        """
+        if isinstance(item, str):
+            return re.sub(r'\$\{(.*?)\}', replacer, item)
+        elif isinstance(item, dict):
+            return {key: recursive_replace(value) for key, value in item.items()}
+        elif isinstance(item, list):
+            return [recursive_replace(i) for i in item]
+        else:
+            return item
+
+    return recursive_replace(deploy_data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ Werkzeug==2.0.1
 oauth2client==4.1.3
 ruamel.yaml==0.17.16
 boto3==1.20.46
-micado-parser==0.12.1
+micado-parser==0.12.2
 dockubeadt~=0.2.0


### PR DESCRIPTION
- Adds support for braced parameter expansion
  - supporting both open_parameters and MODEL/DATA parameters

```yaml
db:
  image: ${MS_DOCKER_IMG}
  command: python run app.py ${MODEL.path}/${MODEL.filename}
```