### PR TITLE
Do not double-define params

### DIFF
--- a/templates/mdt.yaml
+++ b/templates/mdt.yaml
@@ -22,20 +22,6 @@ imports:
 node_types:
   micado.microservice.{{ id }}:
     derived_from: micado.microservice
-    {%- if parameters %}
-    properties:
-    {%- endif %}
-      {%- for param in parameters %}
-      {{ param['name'] }}:
-        type: "{{ param['type'] }}"
-        description: "{{ param['description'] }}"
-        {%- if param[ 'defaultValue' ] != None %}
-        default: {{ param['defaultValue'] }}
-        {%- endif %}
-        {%- if param[ 'mandatory' ] != None %}
-        required: {{ param['mandatory'] }}
-        {%- endif %}
-      {%- endfor %}
 
 topology_template:
   {%- if parameters %}


### PR DESCRIPTION
- fixes an issue where the parser would complain about missing required parameters