### PR TITLE
Handle open params in command

### DIFF
--- a/adtg_compile.py
+++ b/adtg_compile.py
@@ -29,16 +29,16 @@ def rendering_open_parameters(data):
     else:
         d = str(data)
         # Match the value of the key/value pair
-        match = re.match(r'^open_parameter\("?(.*?)"?\)$', d)
+        match = re.match(r'^open_parameter\{"?(.*?)"?\}$', d)
         if match:
             return {'get_input': match.group(1).strip()}
         
         # Match within the string
-        matches = re.findall(r'open_parameter\("?(.*?)"?\)', d)
+        matches = re.findall(r'open_parameter\{"?(.*?)"?\}', d)
         for match in matches:
             param_value = match.strip().strip('\"').strip('\'')
             replace_value = f'{{ get_input: {param_value} }}'
-            return d.replace(f'open_parameter({match})', replace_value)
+            return d.replace(f'open_parameter{{{match}}}', replace_value)
         return data
 
 def compile(log, full_wd, asset_type, asset_dict, template_file):

--- a/adtg_utils.py
+++ b/adtg_utils.py
@@ -24,7 +24,7 @@ def handle_env_braces(deploy_data: dict, ms_params: list) -> dict:
         """
         variable_name = match.group(1)
         if variable_name in params:
-            return f'open_parameter({variable_name})'
+            return f'open_parameter{{{variable_name}}}'
         else:
             return f'{{{{ {variable_name} }}}}'  
 


### PR DESCRIPTION
- Internally this changes open_parameter(...) to open_parameter{...}
- Fixes an issue where Docker doesn't allow round brackets in commands